### PR TITLE
Switch to non-deprecated rule format

### DIFF
--- a/lib/rules/asserts-limit.js
+++ b/lib/rules/asserts-limit.js
@@ -14,77 +14,82 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
-  var insideIt = false;
-  var assertsCounter = 0;
-  var options = context.options[0] || {};
-  var assertsLimit = options.assertsLimit >= 1 ? options.assertsLimit : 3;
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var ignoreZeroAssertionsIfDoneExists = hasOwnProperty.call(options, "ignoreZeroAssertionsIfDoneExists") ? options.ignoreZeroAssertionsIfDoneExists : true;
-  var nodeSkipped;
-  var doneExists;
+module.exports = {
+  create: function (context) {
+    var insideIt = false;
+    var assertsCounter = 0;
+    var options = context.options[0] || {};
+    var assertsLimit = options.assertsLimit >= 1 ? options.assertsLimit : 3;
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var ignoreZeroAssertionsIfDoneExists = hasOwnProperty.call(options, "ignoreZeroAssertionsIfDoneExists") ? options.ignoreZeroAssertionsIfDoneExists : true;
+    var nodeSkipped;
+    var doneExists;
 
-  function check(node) {
-    if (!insideIt || nodeSkipped) {
-      return;
-    }
-    if (n.isAssertion(node)) {
-      return assertsCounter++;
-    }
-  }
-
-  function fEnter(node) {
-    if (n.isTestBody(node)) {
-      if (skipSkipped) {
-        nodeSkipped = n.tryDetectSkipInParent(node);
+    function check(node) {
+      if (!insideIt || nodeSkipped) {
+        return;
       }
-      doneExists = node.params.length > 0;
-      insideIt = true;
-    }
-  }
-
-  function fExit(node) {
-    if (n.isTestBody(node)) {
-      if (assertsCounter > assertsLimit) {
-        context.report(node.parent, "Too many assertions ({{num}}). Maximum allowed is {{max}}.", {
-          max: assertsLimit,
-          num: assertsCounter
-        });
+      if (n.isAssertion(node)) {
+        return assertsCounter++;
       }
-      if (assertsCounter === 0 && !nodeSkipped && !(ignoreZeroAssertionsIfDoneExists && doneExists)) {
-        context.report(node.parent, "Test without assertions is not allowed.");
-      }
-      insideIt = false;
-      nodeSkipped = false;
-      doneExists = false;
-      assertsCounter = 0;
     }
-  }
 
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "MemberExpression": check,
-    "CallExpression": check
-  };
+    function fEnter(node) {
+      if (n.isTestBody(node)) {
+        if (skipSkipped) {
+          nodeSkipped = n.tryDetectSkipInParent(node);
+        }
+        doneExists = node.params.length > 0;
+        insideIt = true;
+      }
+    }
+
+    function fExit(node) {
+      if (n.isTestBody(node)) {
+        if (assertsCounter > assertsLimit) {
+          context.report(node.parent, "Too many assertions ({{num}}). Maximum allowed is {{max}}.", {
+            max: assertsLimit,
+            num: assertsCounter
+          });
+        }
+        if (assertsCounter === 0 && !nodeSkipped && !(ignoreZeroAssertionsIfDoneExists && doneExists)) {
+          context.report(node.parent, "Test without assertions is not allowed.");
+        }
+        insideIt = false;
+        nodeSkipped = false;
+        doneExists = false;
+        assertsCounter = 0;
+      }
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "MemberExpression": check,
+      "CallExpression": check
+    };
+  },
+
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          assertsLimit: {
+            type: "number"
+          },
+          skipSkipped: {
+            type: "boolean"
+          },
+          ignoreZeroAssertionsIfDoneExists: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  }
 };
-
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      assertsLimit: {
-        type: "number"
-      },
-      skipSkipped: {
-        type: "boolean"
-      },
-      ignoreZeroAssertionsIfDoneExists: {
-        type: "boolean"
-      }
-    },
-    additionalProperties: false
-  }
-];

--- a/lib/rules/complexity-it.js
+++ b/lib/rules/complexity-it.js
@@ -14,99 +14,104 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var insideIt = false;
-  var currentComplexityCount = 0;
-  var options = context.options[0] || {};
-  var maxAllowedComplexity = hasOwnProperty.call(options, "maxAllowedComplexity") ? options.maxAllowedComplexity : 40;
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var nodeSkipped;
+    var insideIt = false;
+    var currentComplexityCount = 0;
+    var options = context.options[0] || {};
+    var maxAllowedComplexity = hasOwnProperty.call(options, "maxAllowedComplexity") ? options.maxAllowedComplexity : 40;
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var nodeSkipped;
 
-  function increaseComplexity() {
-    if (!insideIt) {
-      return;
-    }
-    if (nodeSkipped) {
-      return;
-    }
-    currentComplexityCount++;
-  }
-
-  function fEnter (node) {
-    if (n.isTestBody(node)) {
-      if (skipSkipped) {
-        nodeSkipped = n.tryDetectSkipInParent(node);
-      }
-      insideIt = true;
-    }
-  }
-
-  function fExit (node) {
-    if (n.isTestBody(node)) {
-      if (currentComplexityCount > maxAllowedComplexity) {
-        context.report(node.parent, "`{{name}}` has a complexity of {{num}}. Maximum allowed is {{max}}.", {
-          max: maxAllowedComplexity,
-          num: currentComplexityCount,
-          name: n.getCaller(node.parent)
-        });
-      }
-      insideIt = false;
-      nodeSkipped = false;
-      currentComplexityCount = 0;
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-
-    "MemberExpression": function (node) {
-      if (n.isSinonAssert(node) || n.isChaiAssert(node) || n.isChaiShould(node) || n.isChaiChainable(node)) {
+    function increaseComplexity() {
+      if (!insideIt) {
         return;
       }
-      if (node.parent.type === "MemberExpression") {
+      if (nodeSkipped) {
         return;
       }
-      increaseComplexity();
-    },
+      currentComplexityCount++;
+    }
 
-    "CallExpression": function (node) {
-      if (n.isChaiExpect(node)) {
-        return;
+    function fEnter (node) {
+      if (n.isTestBody(node)) {
+        if (skipSkipped) {
+          nodeSkipped = n.tryDetectSkipInParent(node);
+        }
+        insideIt = true;
       }
-      increaseComplexity();
-    },
+    }
 
-    "FunctionDeclaration": increaseComplexity,
-    "ExpressionStatement": increaseComplexity,
-    "CatchClause": increaseComplexity,
-    "ConditionalExpression": increaseComplexity,
-    "LogicalExpression": increaseComplexity,
-    "ForStatement": increaseComplexity,
-    "ForInStatement": increaseComplexity,
-    "ForOfStatement": increaseComplexity,
-    "IfStatement": increaseComplexity,
-    "SwitchCase": increaseComplexity,
-    "WhileStatement": increaseComplexity,
-    "DoWhileStatement": increaseComplexity
+    function fExit (node) {
+      if (n.isTestBody(node)) {
+        if (currentComplexityCount > maxAllowedComplexity) {
+          context.report(node.parent, "`{{name}}` has a complexity of {{num}}. Maximum allowed is {{max}}.", {
+            max: maxAllowedComplexity,
+            num: currentComplexityCount,
+            name: n.getCaller(node.parent)
+          });
+        }
+        insideIt = false;
+        nodeSkipped = false;
+        currentComplexityCount = 0;
+      }
+    }
 
-  };
-};
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      maxAllowedComplexity: {
-        type: "number"
+      "MemberExpression": function (node) {
+        if (n.isSinonAssert(node) || n.isChaiAssert(node) || n.isChaiShould(node) || n.isChaiChainable(node)) {
+          return;
+        }
+        if (node.parent.type === "MemberExpression") {
+          return;
+        }
+        increaseComplexity();
       },
-      skipSkipped: {
-        type: "boolean"
+
+      "CallExpression": function (node) {
+        if (n.isChaiExpect(node)) {
+          return;
+        }
+        increaseComplexity();
+      },
+
+      "FunctionDeclaration": increaseComplexity,
+      "ExpressionStatement": increaseComplexity,
+      "CatchClause": increaseComplexity,
+      "ConditionalExpression": increaseComplexity,
+      "LogicalExpression": increaseComplexity,
+      "ForStatement": increaseComplexity,
+      "ForInStatement": increaseComplexity,
+      "ForOfStatement": increaseComplexity,
+      "IfStatement": increaseComplexity,
+      "SwitchCase": increaseComplexity,
+      "WhileStatement": increaseComplexity,
+      "DoWhileStatement": increaseComplexity
+
+    };
+  },
+
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          maxAllowedComplexity: {
+            type: "number"
+          },
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
       }
-    },
-    additionalProperties: false
+    ]
   }
-];
+};

--- a/lib/rules/disallow-stub-spy-restore-in-it.js
+++ b/lib/rules/disallow-stub-spy-restore-in-it.js
@@ -13,60 +13,65 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+    create: function (context) {
 
-  var disallowed = ["stub", "spy", "restore"];
-  var insideTest = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var nodeSkipped = false;
-  var caller = "";
+    var disallowed = ["stub", "spy", "restore"];
+    var insideTest = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var nodeSkipped = false;
+    var caller = "";
 
-  function fEnter (node) {
-    if (n.isTestBody(node)) {
-      if (skipSkipped) {
-        nodeSkipped = n.tryDetectSkipInParent(node);
+    function fEnter (node) {
+      if (n.isTestBody(node)) {
+        if (skipSkipped) {
+          nodeSkipped = n.tryDetectSkipInParent(node);
+        }
+        insideTest = true;
+        caller = n.getCaller(node.parent);
       }
-      insideTest = true;
-      caller = n.getCaller(node.parent);
     }
-  }
 
-  function fExit(node) {
-    if (n.isTestBody(node)) {
-      insideTest = false;
-      nodeSkipped = false;
-      caller = "";
+    function fExit(node) {
+      if (n.isTestBody(node)) {
+        insideTest = false;
+        nodeSkipped = false;
+        caller = "";
+      }
     }
-  }
 
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
 
-    "CallExpression": function (node) {
-      var callee = obj.get(node, "callee");
-      if (callee) {
-        var _c = n.cleanCaller(n.getCaller(callee)).split(".").pop();
-        if (insideTest && disallowed.indexOf(_c) !== -1 && !nodeSkipped) {
-          context.report(node, "`{{name}}` is not allowed to use inside `{{caller}}`.", {name: _c, caller: caller});
+      "CallExpression": function (node) {
+        var callee = obj.get(node, "callee");
+        if (callee) {
+          var _c = n.cleanCaller(n.getCaller(callee)).split(".").pop();
+          if (insideTest && disallowed.indexOf(_c) !== -1 && !nodeSkipped) {
+            context.report(node, "`{{name}}` is not allowed to use inside `{{caller}}`.", {name: _c, caller: caller});
+          }
         }
       }
-    }
 
-  };
-};
+    };
+  },
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+  meta: {
+    type: "problem",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
       }
-    },
-    additionalProperties: false
+    ]
   }
-];
+};

--- a/lib/rules/disallow-stub-window.js
+++ b/lib/rules/disallow-stub-window.js
@@ -13,44 +13,49 @@ var obj = require("../utils/obj.js");
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var m = "`sinon.stub` should not be used for `window.{{methodName}}`";
+    var m = "`sinon.stub` should not be used for `window.{{methodName}}`";
 
-  var options = context.options[0] || {};
-  var methods = options.methods;
+    var options = context.options[0] || {};
+    var methods = options.methods;
 
-  return {
-    "CallExpression": function (node) {
-      if (!n.isSinonStub(node)) {
-        return;
+    return {
+      "CallExpression": function (node) {
+        if (!n.isSinonStub(node)) {
+          return;
+        }
+        if (obj.get(node, "arguments.0.name") !== "window") {
+          return;
+        }
+        var methodName = obj.get(node, "arguments.1.value");
+        if (methods.indexOf(methodName) !== -1) {
+          context.report(node, m, {methodName: methodName});
+        }
       }
-      if (obj.get(node, "arguments.0.name") !== "window") {
-        return;
-      }
-      var methodName = obj.get(node, "arguments.1.value");
-      if (methods.indexOf(methodName) !== -1) {
-        context.report(node, m, {methodName: methodName});
-      }
-    }
 
-  };
-};
+    };
+  },
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      methods: {
-        type: "array",
-        items: {
-          type: "string"
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          methods: {
+            type: "array",
+            items: {
+              type: "string"
+            },
+            minItems: 1,
+            uniqueItems: true
+          }
         },
-        minItems: 1,
-        uniqueItems: true
+        requiredProperties: ["methods"],
+        additionalProperties: false
       }
-    },
-    requiredProperties: ["methods"],
-    additionalProperties: false
+    ]
   }
-];
+};

--- a/lib/rules/disallowed-usage.js
+++ b/lib/rules/disallowed-usage.js
@@ -44,146 +44,151 @@ function prepareProperties(parts) {
   return ret;
 }
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var insideTest = false;
-  var insideHook = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var disallowedMethodsInTests = hasOwnProperty.call(options, "test") ? prepareCallers(options.test) : [];
-  var disallowedPropertiesInTests = hasOwnProperty.call(options, "test") ? prepareProperties(options.test) : [];
-  var disallowedMethodsInHooks = hasOwnProperty.call(options, "hook") ? prepareCallers(options.hook) : [];
-  var disallowedPropertiesInHooks = hasOwnProperty.call(options, "hook") ? prepareProperties(options.hook) : [];
+    var insideTest = false;
+    var insideHook = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var disallowedMethodsInTests = hasOwnProperty.call(options, "test") ? prepareCallers(options.test) : [];
+    var disallowedPropertiesInTests = hasOwnProperty.call(options, "test") ? prepareProperties(options.test) : [];
+    var disallowedMethodsInHooks = hasOwnProperty.call(options, "hook") ? prepareCallers(options.hook) : [];
+    var disallowedPropertiesInHooks = hasOwnProperty.call(options, "hook") ? prepareProperties(options.hook) : [];
 
-  function detect(flag, disallowed, caller, node) {
-    return flag && disallowed.indexOf(caller) !== -1 && !(skipSkipped && n.tryDetectSkipInParent(node));
+    function detect(flag, disallowed, caller, node) {
+      return flag && disallowed.indexOf(caller) !== -1 && !(skipSkipped && n.tryDetectSkipInParent(node));
+    }
+
+    function fEnter(node) {
+      if (n.isTestBody(node)) {
+        insideTest = true;
+      }
+      if (n.isHookBody(node)) {
+        insideHook = true;
+      }
+    }
+
+    function fExit(node) {
+      if (n.isTestBody(node)) {
+        insideTest = false;
+      }
+      if (n.isHookBody(node)) {
+        insideHook = false;
+      }
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "CallExpression": function (node) {
+        var parent = obj.get(node, "parent");
+        if (!parent) {
+          return;
+        }
+        var caller = n.cleanCaller(n.getCaller(node));
+        if (!caller) {
+          return;
+        }
+        if (detect(insideTest, disallowedMethodsInTests, caller, node)) {
+          context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
+        }
+        if (detect(insideHook, disallowedMethodsInHooks, caller, node)) {
+          context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
+        }
+      },
+      "MemberExpression": function (node) {
+        var parent = obj.get(node, "parent");
+        if (!parent) {
+          return;
+        }
+        if (parent.type === "CallExpression" && parent.arguments.indexOf(node) === -1) {
+          return;
+        }
+        var caller = n.cleanCaller(n.getCaller(node));
+        if (detect(insideTest, disallowedPropertiesInTests, caller, node)) {
+          context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
+        }
+        if (detect(insideHook, disallowedPropertiesInHooks, caller, node)) {
+          context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
+        }
+      }
+    };
+  },
+
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          hook: {
+            type: "array",
+            item: {
+              type: "object",
+              properties: {
+                "o": {
+                  type: "string"
+                },
+                "m": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "uniqueItems": true
+                },
+                "f": {
+                  type: "string"
+                },
+                "p": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "uniqueItems": true
+                }
+              }
+            }
+          },
+          test: {
+            type: "array",
+            item: {
+              properties: {
+                "o": {
+                  type: "string"
+                },
+                "m": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "uniqueItems": true
+                },
+                "f": {
+                  type: "string"
+                },
+                "p": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "minItems": 1,
+                  "uniqueItems": true
+                }
+              }
+            }
+          },
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-
-  function fEnter(node) {
-    if (n.isTestBody(node)) {
-      insideTest = true;
-    }
-    if (n.isHookBody(node)) {
-      insideHook = true;
-    }
-  }
-
-  function fExit(node) {
-    if (n.isTestBody(node)) {
-      insideTest = false;
-    }
-    if (n.isHookBody(node)) {
-      insideHook = false;
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "CallExpression": function (node) {
-      var parent = obj.get(node, "parent");
-      if (!parent) {
-        return;
-      }
-      var caller = n.cleanCaller(n.getCaller(node));
-      if (!caller) {
-        return;
-      }
-      if (detect(insideTest, disallowedMethodsInTests, caller, node)) {
-        context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
-      }
-      if (detect(insideHook, disallowedMethodsInHooks, caller, node)) {
-        context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
-      }
-    },
-    "MemberExpression": function (node) {
-      var parent = obj.get(node, "parent");
-      if (!parent) {
-        return;
-      }
-      if (parent.type === "CallExpression" && parent.arguments.indexOf(node) === -1) {
-        return;
-      }
-      var caller = n.cleanCaller(n.getCaller(node));
-      if (detect(insideTest, disallowedPropertiesInTests, caller, node)) {
-        context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
-      }
-      if (detect(insideHook, disallowedPropertiesInHooks, caller, node)) {
-        context.report(node, "`{{caller}}` is not allowed here.", {caller: caller});
-      }
-    }
-  };
 };
-
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      hook: {
-        type: "array",
-        item: {
-          type: "object",
-          properties: {
-            "o": {
-              type: "string"
-            },
-            "m": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            },
-            "f": {
-              type: "string"
-            },
-            "p": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        }
-      },
-      test: {
-        type: "array",
-        item: {
-          properties: {
-            "o": {
-              type: "string"
-            },
-            "m": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            },
-            "f": {
-              type: "string"
-            },
-            "p": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1,
-              "uniqueItems": true
-            }
-          }
-        }
-      },
-      skipSkipped: {
-        type: "boolean"
-      }
-    },
-    additionalProperties: false
-  }
-];

--- a/lib/rules/invalid-assertions.js
+++ b/lib/rules/invalid-assertions.js
@@ -12,73 +12,78 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
-  var m = "Invalid assertion usage.";
-  var insideIt = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var nodeSkipped;
+module.exports = {
+  create: function (context) {
+    var m = "Invalid assertion usage.";
+    var insideIt = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var nodeSkipped;
 
-  function check(node) {
-    if (!insideIt || nodeSkipped) {
-      return;
-    }
-    if (n.isAssertion(node)) {
-      var parentExpression = n.getParentExpression(node);
-      if (!parentExpression) {
+    function check(node) {
+      if (!insideIt || nodeSkipped) {
         return;
       }
-      var caller = n.getCaller(parentExpression.expression) || "";
-      if (["expect", "chai.expect"].indexOf(caller) !== -1) {
-        return context.report(node, m);
-      }
-      var should = "should";
-      if (caller.indexOf(should, caller.length - should.length) !== -1) {
-        return context.report(node, m);
-      }
-      n.chaiChainable.forEach(function (c) {
-        var _c = "." + c;
-        if (caller.indexOf(_c, caller.length - _c.length) !== -1) {
-          context.report(node, m);
+      if (n.isAssertion(node)) {
+        var parentExpression = n.getParentExpression(node);
+        if (!parentExpression) {
+          return;
         }
-      });
-    }
-  }
-
-  function fEnter(node) {
-    if (n.isTestBody(node)) {
-      if (skipSkipped) {
-        nodeSkipped = n.tryDetectSkipInParent(node);
+        var caller = n.getCaller(parentExpression.expression) || "";
+        if (["expect", "chai.expect"].indexOf(caller) !== -1) {
+          return context.report(node, m);
+        }
+        var should = "should";
+        if (caller.indexOf(should, caller.length - should.length) !== -1) {
+          return context.report(node, m);
+        }
+        n.chaiChainable.forEach(function (c) {
+          var _c = "." + c;
+          if (caller.indexOf(_c, caller.length - _c.length) !== -1) {
+            context.report(node, m);
+          }
+        });
       }
-      insideIt = true;
     }
-  }
 
-  function fExit(node) {
-    if (n.isTestBody(node)) {
-      insideIt = false;
-      nodeSkipped = false;
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "CallExpression": check,
-    "MemberExpression": check
-  };
-};
-
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+    function fEnter(node) {
+      if (n.isTestBody(node)) {
+        if (skipSkipped) {
+          nodeSkipped = n.tryDetectSkipInParent(node);
+        }
+        insideIt = true;
       }
-    },
-    additionalProperties: false
+    }
+
+    function fExit(node) {
+      if (n.isTestBody(node)) {
+        insideIt = false;
+        nodeSkipped = false;
+      }
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "CallExpression": check,
+      "MemberExpression": check
+    };
+  },
+
+  meta: {
+    type: "problem",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-];
+}

--- a/lib/rules/no-assertions-in-loop.js
+++ b/lib/rules/no-assertions-in-loop.js
@@ -12,97 +12,102 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
-  var loopStatements = ["WhileStatement", "DoWhileStatement", "ForStatement", "ForInStatement", "ForOfStatement"];
-  var insideIt = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var extraMemberExpression = hasOwnProperty.call(options, "extraMemberExpression") ? options.extraMemberExpression : [];
-  var nodeSkipped;
+module.exports = {
+  create: function (context) {
+    var loopStatements = ["WhileStatement", "DoWhileStatement", "ForStatement", "ForInStatement", "ForOfStatement"];
+    var insideIt = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var extraMemberExpression = hasOwnProperty.call(options, "extraMemberExpression") ? options.extraMemberExpression : [];
+    var nodeSkipped;
 
-  function detectParentLoopInTest(node) {
-    if (!node) {
-      return false;
-    }
-    if (n.isTestBody(node)) {
-      return false;
-    }
-    var caller = "" + n.getCaller(node);
-    var isExtra = false;
-    extraMemberExpression.forEach(function (str) {
-      if (caller.indexOf(str, caller.length - str.length) !== -1) {
-        isExtra = true;
+    function detectParentLoopInTest(node) {
+      if (!node) {
+        return false;
       }
-    });
-    if (isExtra || loopStatements.indexOf(node.type) !== -1) {
-      return true;
-    }
-    return detectParentLoopInTest(node.parent);
-  }
-
-  function fEnter(node) {
-    if (n.isTestBody(node)) {
-      if (skipSkipped) {
-        nodeSkipped = n.tryDetectSkipInParent(node);
+      if (n.isTestBody(node)) {
+        return false;
       }
-      insideIt = true;
-    }
-  }
-
-  function fExit(node) {
-    if (n.isTestBody(node)) {
-      insideIt = false;
-      nodeSkipped = false;
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-
-    "MemberExpression": function (node) {
-      if (!insideIt || nodeSkipped) {
-        return;
-      }
-
-      if (n.isSinonAssert(node) || n.isChaiAssert(node) || n.isChaiShould(node)) {
-        if (detectParentLoopInTest(node.parent)) {
-          context.report(node, "Assertions should not be used in loops.");
+      var caller = "" + n.getCaller(node);
+      var isExtra = false;
+      extraMemberExpression.forEach(function (str) {
+        if (caller.indexOf(str, caller.length - str.length) !== -1) {
+          isExtra = true;
         }
+      });
+      if (isExtra || loopStatements.indexOf(node.type) !== -1) {
+        return true;
       }
-    },
+      return detectParentLoopInTest(node.parent);
+    }
 
-    "CallExpression": function (node) {
-      if (!insideIt || nodeSkipped) {
-        return;
-      }
-      if (n.isChaiExpect(node) || n.isChaiAssert(node)) {
-        if (detectParentLoopInTest(node.parent)) {
-          context.report(node, "Assertions should not be used in loops.");
+    function fEnter(node) {
+      if (n.isTestBody(node)) {
+        if (skipSkipped) {
+          nodeSkipped = n.tryDetectSkipInParent(node);
         }
+        insideIt = true;
       }
     }
 
-  };
-};
+    function fExit(node) {
+      if (n.isTestBody(node)) {
+        insideIt = false;
+        nodeSkipped = false;
+      }
+    }
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+
+      "MemberExpression": function (node) {
+        if (!insideIt || nodeSkipped) {
+          return;
+        }
+
+        if (n.isSinonAssert(node) || n.isChaiAssert(node) || n.isChaiShould(node)) {
+          if (detectParentLoopInTest(node.parent)) {
+            context.report(node, "Assertions should not be used in loops.");
+          }
+        }
       },
-      extraMemberExpression: {
-        type: "array",
-        items: {
-          type: "string"
+
+      "CallExpression": function (node) {
+        if (!insideIt || nodeSkipped) {
+          return;
+        }
+        if (n.isChaiExpect(node) || n.isChaiAssert(node)) {
+          if (detectParentLoopInTest(node.parent)) {
+            context.report(node, "Assertions should not be used in loops.");
+          }
         }
       }
-    },
-    additionalProperties: false
+
+    };
+  },
+
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          },
+          extraMemberExpression: {
+            type: "array",
+            items: {
+              type: "string"
+            }
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-];
+}

--- a/lib/rules/no-assertions-outside-it.js
+++ b/lib/rules/no-assertions-outside-it.js
@@ -14,69 +14,74 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var insideIt = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var insideIt = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
 
-  var message = "Assertion outside tests is not allowed.";
+    var message = "Assertion outside tests is not allowed.";
 
-  function check(node) {
-    if (!insideIt && n.isAssertion(node) && !(skipSkipped && n.tryDetectSkipInParent(node))) {
-      var parentNode = node.parent;
-      var types = ["FunctionExpression", "ArrowFunctionExpression"];
+    function check(node) {
+      if (!insideIt && n.isAssertion(node) && !(skipSkipped && n.tryDetectSkipInParent(node))) {
+        var parentNode = node.parent;
+        var types = ["FunctionExpression", "ArrowFunctionExpression"];
 
-      while (parentNode) {
-        var type = parentNode.type;
-        if (type === "FunctionDeclaration") {
-          return;
-        }
-        if (types.indexOf(type) !== -1) {
-          var caller = n.getCaller(parentNode.parent);
-          if (!caller) {
+        while (parentNode) {
+          var type = parentNode.type;
+          if (type === "FunctionDeclaration") {
             return;
           }
-          if (m.allSuites.indexOf(caller) !== -1 || obj.get(parentNode, "parent.arguments.1") === parentNode) {
-            return context.report(node.parent, message);
+          if (types.indexOf(type) !== -1) {
+            var caller = n.getCaller(parentNode.parent);
+            if (!caller) {
+              return;
+            }
+            if (m.allSuites.indexOf(caller) !== -1 || obj.get(parentNode, "parent.arguments.1") === parentNode) {
+              return context.report(node.parent, message);
+            }
           }
+          parentNode = parentNode.parent;
         }
-        parentNode = parentNode.parent;
+        return context.report(node.parent, message);
       }
-      return context.report(node.parent, message);
     }
-  }
 
-  function fEnter (node) {
-    if (n.isTestBody(node)) {
-      insideIt = true;
-    }
-  }
-
-  function fExit (node) {
-    if (n.isTestBody(node)) {
-      insideIt = false;
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "MemberExpression": check,
-    "CallExpression": check
-  };
-};
-
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+    function fEnter (node) {
+      if (n.isTestBody(node)) {
+        insideIt = true;
       }
-    },
-    additionalProperties: false
+    }
+
+    function fExit (node) {
+      if (n.isTestBody(node)) {
+        insideIt = false;
+      }
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "MemberExpression": check,
+      "CallExpression": check
+    };
+  },
+
+  meta: {
+    type: "problem",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-];
+}

--- a/lib/rules/no-empty-body.js
+++ b/lib/rules/no-empty-body.js
@@ -16,36 +16,41 @@ var toCheck = mocha.all.concat(mocha.hooks);
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+module.exports = {
+  create: function (context) {
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
 
-  function fEnter (node) {
-    if (skipSkipped && n.tryDetectSkipInParent(node)) {
-      return;
-    }
-    var caller = n.getCaller(node.parent);
-    if (toCheck.indexOf(caller) !== -1) {
-      if (!obj.get(node, "body.body.length")) {
-        context.report(node, "Empty function is not allowed here.");
+    function fEnter (node) {
+      if (skipSkipped && n.tryDetectSkipInParent(node)) {
+        return;
+      }
+      var caller = n.getCaller(node.parent);
+      if (toCheck.indexOf(caller) !== -1) {
+        if (!obj.get(node, "body.body.length")) {
+          context.report(node, "Empty function is not allowed here.");
+        }
       }
     }
-  }
 
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter
-  };
-};
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter
+    };
+  },
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+  meta: {
+    type: "problem",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
       }
-    },
-    additionalProperties: false
+    ]
   }
-];
+}

--- a/lib/rules/no-empty-title.js
+++ b/lib/rules/no-empty-title.js
@@ -14,42 +14,47 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
 
-  return {
-    "CallExpression": function (node) {
-      var caller = n.getCaller(node);
-      if (!caller || mocha.all.indexOf(caller) === -1) {
-        return;
-      }
-      if (skipSkipped && (mocha.allSkipped.indexOf(caller) !== -1 || n.tryDetectSkipInParent(node))) {
-        return;
-      }
-
-      var firstArgType = obj.get(node, "arguments.0.type");
-      if (firstArgType === "Literal") {
-        var title = "" + obj.get(node, "arguments.0.value") || "";
-        if (!title.trim()) {
-          context.report(node, "Empty title is not allowed for `{{name}}`.", {name: caller});
+    return {
+      "CallExpression": function (node) {
+        var caller = n.getCaller(node);
+        if (!caller || mocha.all.indexOf(caller) === -1) {
+          return;
         }
+        if (skipSkipped && (mocha.allSkipped.indexOf(caller) !== -1 || n.tryDetectSkipInParent(node))) {
+          return;
+        }
+
+        var firstArgType = obj.get(node, "arguments.0.type");
+        if (firstArgType === "Literal") {
+          var title = "" + obj.get(node, "arguments.0.value") || "";
+          if (!title.trim()) {
+            context.report(node, "Empty title is not allowed for `{{name}}`.", {name: caller});
+          }
+        }
+
       }
 
-    }
+    };
+  },
 
-  };
-};
-
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
       }
-    },
-    additionalProperties: false
+    ]
   }
-];
+}

--- a/lib/rules/no-eql-primitives.js
+++ b/lib/rules/no-eql-primitives.js
@@ -13,86 +13,91 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var strictCheck = ["assert.deepEqual", "assert.notDeepEqual"];
-  var notStrictCheck = [".eql", ".deep.equal"];
-  var insideTest = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var strictCheck = ["assert.deepEqual", "assert.notDeepEqual"];
+    var notStrictCheck = [".eql", ".deep.equal"];
+    var insideTest = false;
 
-  function isPrimitive(arg) {
-    var type = obj.getType(arg.value);
-    return ["string", "number", "boolean", "null"].indexOf(type) !== -1;
-  }
-
-  function fEnter (node) {
-    if (n.isTestBody(node)) {
-      insideTest = true;
+    function isPrimitive(arg) {
+      var type = obj.getType(arg.value);
+      return ["string", "number", "boolean", "null"].indexOf(type) !== -1;
     }
-  }
 
-  function fExit (node) {
-    if (n.isTestBody(node)) {
-      insideTest = false;
+    function fEnter (node) {
+      if (n.isTestBody(node)) {
+        insideTest = true;
+      }
     }
-  }
 
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "MemberExpression": function (node) {
-      if (insideTest && !(skipSkipped && n.tryDetectSkipInParent(node))) {
-        var caller = n.getCaller(node);
-        if (!caller) {
-          return;
-        }
-        var args;
-        // check as assert.*
-        if (strictCheck.indexOf(caller) !== -1) {
-          args = obj.get(node, "parent.arguments");
-          if (args.length > 1 && args[1].type === "Literal") {
-            if (isPrimitive(args[1])) {
-              context.report(node, "`{{caller}}` should not be used with primitives.", {caller: caller});
+    function fExit (node) {
+      if (n.isTestBody(node)) {
+        insideTest = false;
+      }
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "MemberExpression": function (node) {
+        if (insideTest && !(skipSkipped && n.tryDetectSkipInParent(node))) {
+          var caller = n.getCaller(node);
+          if (!caller) {
+            return;
+          }
+          var args;
+          // check as assert.*
+          if (strictCheck.indexOf(caller) !== -1) {
+            args = obj.get(node, "parent.arguments");
+            if (args.length > 1 && args[1].type === "Literal") {
+              if (isPrimitive(args[1])) {
+                context.report(node, "`{{caller}}` should not be used with primitives.", {caller: caller});
+              }
             }
+            return;
           }
-          return;
-        }
 
-        // check as *.eql
-        // Because of chai expect/should logic, MemberExpression may be pretty long.
-        // So, there is not no sense to get it full. We just can check if it ends with needed substring
-        var toCheck = false;
-        var _caller = ""; // used in the report-message
-        notStrictCheck.forEach(function (str) {
-          if (caller.indexOf(str, caller.length - str.length) !== -1) { // endWith -> `some.eql` ends with `.eql`
-            _caller = str;
-            toCheck = true;
-          }
-        });
-        if (toCheck) {
-          args = obj.get(node, "parent.arguments");
-          if (args.length > 0 && args[0].type === "Literal") {
-            if (isPrimitive(args[0])) {
-              context.report(node, "`{{caller}}` should not be used with primitives.", {caller: _caller});
+          // check as *.eql
+          // Because of chai expect/should logic, MemberExpression may be pretty long.
+          // So, there is not no sense to get it full. We just can check if it ends with needed substring
+          var toCheck = false;
+          var _caller = ""; // used in the report-message
+          notStrictCheck.forEach(function (str) {
+            if (caller.indexOf(str, caller.length - str.length) !== -1) { // endWith -> `some.eql` ends with `.eql`
+              _caller = str;
+              toCheck = true;
+            }
+          });
+          if (toCheck) {
+            args = obj.get(node, "parent.arguments");
+            if (args.length > 0 && args[0].type === "Literal") {
+              if (isPrimitive(args[0])) {
+                context.report(node, "`{{caller}}` should not be used with primitives.", {caller: _caller});
+              }
             }
           }
         }
       }
-    }
-  };
-};
+    };
+  },
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
       }
-    },
-    additionalProperties: false
+    ]
   }
-];
+}

--- a/lib/rules/no-expressions-in-assertions.js
+++ b/lib/rules/no-expressions-in-assertions.js
@@ -13,251 +13,256 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
-  var insideIt = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var nodeSkipped;
+module.exports = {
+  create: function (context) {
+    var insideIt = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var nodeSkipped;
 
-  var defaultMessage = "Expression should not be used here.";
-  var detailedMessage = "`{{shouldUse}}` should be used.";
-  var emptyArgMessage = "Empty assertion is not allowed.";
+    var defaultMessage = "Expression should not be used here.";
+    var detailedMessage = "`{{shouldUse}}` should be used.";
+    var emptyArgMessage = "Empty assertion is not allowed.";
 
-  var typesToReportAsDefault = ["ConditionalExpression", "UnaryExpression", "LogicalExpression", "UpdateExpression"];
+    var typesToReportAsDefault = ["ConditionalExpression", "UnaryExpression", "LogicalExpression", "UpdateExpression"];
 
-  var binaryMapForExpect = {
-    "===": ".to.be.equal",
-    "!==": ".to.be.not.equal",
-    "==": ".to.be.equal",
-    "!=": ".to.be.not.equal",
-    ">=": ".to.be.at.least",
-    ">": ".to.be.above",
-    "<=": ".to.be.most",
-    "<": ".to.be.below",
-    "instanceof": ".to.be.instanceof"
-  };
+    var binaryMapForExpect = {
+      "===": ".to.be.equal",
+      "!==": ".to.be.not.equal",
+      "==": ".to.be.equal",
+      "!=": ".to.be.not.equal",
+      ">=": ".to.be.at.least",
+      ">": ".to.be.above",
+      "<=": ".to.be.most",
+      "<": ".to.be.below",
+      "instanceof": ".to.be.instanceof"
+    };
 
-  var binaryMapForAssert = {
-    "===": ".strictEqual",
-    "!==": ".notStrictEqual",
-    "==": ".equal",
-    "!=": ".notEqual",
-    ">=": ".isAtLeast",
-    ">": ".isAbove",
-    "<=": ".isAtMost",
-    "<": ".isBelow"
-  };
+    var binaryMapForAssert = {
+      "===": ".strictEqual",
+      "!==": ".notStrictEqual",
+      "==": ".equal",
+      "!=": ".notEqual",
+      ">=": ".isAtLeast",
+      ">": ".isAbove",
+      "<=": ".isAtMost",
+      "<": ".isBelow"
+    };
 
-  /**
-   *
-   * @param {ASTNode} binaryExpression
-   * @param {ASTNode} node
-   * @returns {*}
-   */
-  function checkBinaryInExpect(binaryExpression, node) {
-    var eqls = ["===", "==", "!==", "!="];
-    var op = binaryExpression.operator;
-    var shouldUse = binaryMapForExpect[op];
-    if (shouldUse) {
-      if (eqls.indexOf(op) === -1) {
-        return context.report(node, detailedMessage, {shouldUse: shouldUse});
-      }
-      var primitives = [null, true, false];
-      for (var i = 0; i < primitives.length; i++) {
-        if (checkForValueInExpect(binaryExpression, op, node, primitives[i])) {
+    /**
+     *
+     * @param {ASTNode} binaryExpression
+     * @param {ASTNode} node
+     * @returns {*}
+     */
+    function checkBinaryInExpect(binaryExpression, node) {
+      var eqls = ["===", "==", "!==", "!="];
+      var op = binaryExpression.operator;
+      var shouldUse = binaryMapForExpect[op];
+      if (shouldUse) {
+        if (eqls.indexOf(op) === -1) {
+          return context.report(node, detailedMessage, {shouldUse: shouldUse});
+        }
+        var primitives = [null, true, false];
+        for (var i = 0; i < primitives.length; i++) {
+          if (checkForValueInExpect(binaryExpression, op, node, primitives[i])) {
+            return;
+          }
+        }
+
+        if (checkForUndefinedInExpect(binaryExpression, op, node)) {
           return;
         }
-      }
-
-      if (checkForUndefinedInExpect(binaryExpression, op, node)) {
-        return;
-      }
-      return context.report(node, detailedMessage, {shouldUse: shouldUse});
-    }
-    return context.report(node, defaultMessage);
-  }
-
-  /**
-   *
-   * @param {ASTNode} binaryExpression
-   * @param {string} op '=='|'==='|'!='|'!=='
-   * @param {ASTNode} node
-   * @param {*} value
-   * @returns {boolean}
-   */
-  function checkForValueInExpect(binaryExpression, op, node, value) {
-    var shouldUse = ".to." + (op[0] === "!" ? "not." : "") + "be." + value;
-    if (obj.get(binaryExpression, "left.value") === value || obj.get(binaryExpression, "right.value") === value) {
-      context.report(node, detailedMessage, {shouldUse: shouldUse});
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   *
-   * @param {ASTNode} binaryExpression
-   * @param {string} op '=='|'==='|'!='|'!=='
-   * @param {ASTNode} node
-   * @returns {boolean}
-   */
-  function checkForUndefinedInExpect(binaryExpression, op, node) {
-    var shouldUse = ".to." + (op[0] === "!" ? "not." : "") + "be.undefined";
-    if (obj.get(binaryExpression, "left.name") === "undefined" || obj.get(binaryExpression, "right.name") === "undefined") {
-      context.report(node, detailedMessage, {shouldUse: shouldUse});
-      return true;
-    }
-    return false;
-  }
-
-  /**
-   *
-   * @param {ASTNode} binaryExpression
-   * @param {ASTNode} node
-   */
-  function checkBinaryInAssert(binaryExpression, node) {
-    var eqls = ["===", "==", "!==", "!="];
-    var op = binaryExpression.operator;
-    var shouldUse = binaryMapForAssert[op];
-    if (shouldUse) {
-      if (eqls.indexOf(op) === -1) {
         return context.report(node, detailedMessage, {shouldUse: shouldUse});
       }
-      var primitives = [null, true, false];
-      for (var i = 0; i < primitives.length; i++) {
-        if (checkForValueAssert(binaryExpression, op, node, primitives[i])) {
+      return context.report(node, defaultMessage);
+    }
+
+    /**
+     *
+     * @param {ASTNode} binaryExpression
+     * @param {string} op '=='|'==='|'!='|'!=='
+     * @param {ASTNode} node
+     * @param {*} value
+     * @returns {boolean}
+     */
+    function checkForValueInExpect(binaryExpression, op, node, value) {
+      var shouldUse = ".to." + (op[0] === "!" ? "not." : "") + "be." + value;
+      if (obj.get(binaryExpression, "left.value") === value || obj.get(binaryExpression, "right.value") === value) {
+        context.report(node, detailedMessage, {shouldUse: shouldUse});
+        return true;
+      }
+      return false;
+    }
+
+    /**
+     *
+     * @param {ASTNode} binaryExpression
+     * @param {string} op '=='|'==='|'!='|'!=='
+     * @param {ASTNode} node
+     * @returns {boolean}
+     */
+    function checkForUndefinedInExpect(binaryExpression, op, node) {
+      var shouldUse = ".to." + (op[0] === "!" ? "not." : "") + "be.undefined";
+      if (obj.get(binaryExpression, "left.name") === "undefined" || obj.get(binaryExpression, "right.name") === "undefined") {
+        context.report(node, detailedMessage, {shouldUse: shouldUse});
+        return true;
+      }
+      return false;
+    }
+
+    /**
+     *
+     * @param {ASTNode} binaryExpression
+     * @param {ASTNode} node
+     */
+    function checkBinaryInAssert(binaryExpression, node) {
+      var eqls = ["===", "==", "!==", "!="];
+      var op = binaryExpression.operator;
+      var shouldUse = binaryMapForAssert[op];
+      if (shouldUse) {
+        if (eqls.indexOf(op) === -1) {
+          return context.report(node, detailedMessage, {shouldUse: shouldUse});
+        }
+        var primitives = [null, true, false];
+        for (var i = 0; i < primitives.length; i++) {
+          if (checkForValueAssert(binaryExpression, op, node, primitives[i])) {
+            return;
+          }
+        }
+
+        if (checkForUndefinedAssert(binaryExpression, op, node)) {
           return;
         }
+        return context.report(node, detailedMessage, {shouldUse: shouldUse});
       }
-
-      if (checkForUndefinedAssert(binaryExpression, op, node)) {
-        return;
-      }
-      return context.report(node, detailedMessage, {shouldUse: shouldUse});
+      return context.report(node, defaultMessage);
     }
-    return context.report(node, defaultMessage);
-  }
 
-  /**
-   *
-   * @param {ASTNode} binaryExpression
-   * @param {string} op '=='|'==='|'!='|'!=='
-   * @param {ASTNode} node
-   * @param {*} value
-   * @returns {boolean}
-   */
-  function checkForValueAssert(binaryExpression, op, node, value) {
-    var _value = "" + value;
-    var shouldUse = ".is" + (op[0] === "!" ? "Not" : "") + _value.charAt(0).toUpperCase() + _value.slice(1);
-    if (obj.get(binaryExpression, "left.value") === value || obj.get(binaryExpression, "right.value") === value) {
-      context.report(node, detailedMessage, {shouldUse: shouldUse});
-      return true;
+    /**
+     *
+     * @param {ASTNode} binaryExpression
+     * @param {string} op '=='|'==='|'!='|'!=='
+     * @param {ASTNode} node
+     * @param {*} value
+     * @returns {boolean}
+     */
+    function checkForValueAssert(binaryExpression, op, node, value) {
+      var _value = "" + value;
+      var shouldUse = ".is" + (op[0] === "!" ? "Not" : "") + _value.charAt(0).toUpperCase() + _value.slice(1);
+      if (obj.get(binaryExpression, "left.value") === value || obj.get(binaryExpression, "right.value") === value) {
+        context.report(node, detailedMessage, {shouldUse: shouldUse});
+        return true;
+      }
+      return false;
     }
-    return false;
-  }
 
-  /**
-   *
-   * @param {ASTNode} binaryExpression
-   * @param {string} op '=='|'==='|'!='|'!=='
-   * @param {ASTNode} node
-   * @returns {boolean}
-   */
-  function checkForUndefinedAssert(binaryExpression, op, node) {
-    var shouldUse = op[0] === "!" ? ".isUndefined" : ".isDefined";
-    if (obj.get(binaryExpression, "left.name") === "undefined" || obj.get(binaryExpression, "right.name") === "undefined") {
-      context.report(node, detailedMessage, {shouldUse: shouldUse});
-      return true;
+    /**
+     *
+     * @param {ASTNode} binaryExpression
+     * @param {string} op '=='|'==='|'!='|'!=='
+     * @param {ASTNode} node
+     * @returns {boolean}
+     */
+    function checkForUndefinedAssert(binaryExpression, op, node) {
+      var shouldUse = op[0] === "!" ? ".isUndefined" : ".isDefined";
+      if (obj.get(binaryExpression, "left.name") === "undefined" || obj.get(binaryExpression, "right.name") === "undefined") {
+        context.report(node, detailedMessage, {shouldUse: shouldUse});
+        return true;
+      }
+      return false;
     }
-    return false;
-  }
 
-  function fEnter (node) {
-    if (n.isTestBody(node)) {
-      if (skipSkipped) {
-        nodeSkipped = n.tryDetectSkipInParent(node);
-      }
-      insideIt = true;
-    }
-  }
-
-  function fExit (node) {
-    if (n.isTestBody(node)) {
-      insideIt = false;
-      nodeSkipped = false;
-    }
-  }
-
-  function dontReport(arg) {
-    return arg.operator === "typeof";
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "CallExpression": function (node) {
-      if (!insideIt || nodeSkipped) {
-        return;
-      }
-      var arg;
-      var isChaiExpect = n.isChaiExpect(node);
-      var isChaiAssert = n.isChaiAssert(node);
-      if (isChaiAssert) {
-        arg = obj.get(node, "arguments.0");
-        if (!arg) {
-          return context.report(node, emptyArgMessage);
+    function fEnter (node) {
+      if (n.isTestBody(node)) {
+        if (skipSkipped) {
+          nodeSkipped = n.tryDetectSkipInParent(node);
         }
-        if (arg.type === "BinaryExpression") {
-          return checkBinaryInAssert(arg, node);
-        }
-        if (typesToReportAsDefault.indexOf(arg.type) !== -1 && !dontReport(arg)) {
-          return context.report(node, defaultMessage);
-        }
-      }
-      if (isChaiExpect) {
-        arg = obj.get(node, "arguments.0");
-        if (!arg) {
-          return context.report(node, emptyArgMessage);
-        }
-        if (arg.type === "BinaryExpression") {
-          return checkBinaryInExpect(arg, node);
-        }
-        if (typesToReportAsDefault.indexOf(arg.type) !== -1 && !dontReport(arg)) {
-          return context.report(node, defaultMessage);
-        }
-      }
-    },
-    "MemberExpression": function (node) {
-      if (!insideIt || nodeSkipped) {
-        return;
-      }
-      var arg;
-      if (n.isChaiAssert(node)) {
-        arg = obj.get(node, "parent.arguments.0");
-        if (!arg) {
-          return context.report(node, emptyArgMessage);
-        }
-        if (arg.type === "BinaryExpression") {
-          return checkBinaryInAssert(arg, node);
-        }
-        if (typesToReportAsDefault.indexOf(arg.type) !== -1 && !dontReport(arg)) {
-          return context.report(node, defaultMessage);
-        }
+        insideIt = true;
       }
     }
-  };
-};
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+    function fExit (node) {
+      if (n.isTestBody(node)) {
+        insideIt = false;
+        nodeSkipped = false;
       }
-    },
-    additionalProperties: false
+    }
+
+    function dontReport(arg) {
+      return arg.operator === "typeof";
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "CallExpression": function (node) {
+        if (!insideIt || nodeSkipped) {
+          return;
+        }
+        var arg;
+        var isChaiExpect = n.isChaiExpect(node);
+        var isChaiAssert = n.isChaiAssert(node);
+        if (isChaiAssert) {
+          arg = obj.get(node, "arguments.0");
+          if (!arg) {
+            return context.report(node, emptyArgMessage);
+          }
+          if (arg.type === "BinaryExpression") {
+            return checkBinaryInAssert(arg, node);
+          }
+          if (typesToReportAsDefault.indexOf(arg.type) !== -1 && !dontReport(arg)) {
+            return context.report(node, defaultMessage);
+          }
+        }
+        if (isChaiExpect) {
+          arg = obj.get(node, "arguments.0");
+          if (!arg) {
+            return context.report(node, emptyArgMessage);
+          }
+          if (arg.type === "BinaryExpression") {
+            return checkBinaryInExpect(arg, node);
+          }
+          if (typesToReportAsDefault.indexOf(arg.type) !== -1 && !dontReport(arg)) {
+            return context.report(node, defaultMessage);
+          }
+        }
+      },
+      "MemberExpression": function (node) {
+        if (!insideIt || nodeSkipped) {
+          return;
+        }
+        var arg;
+        if (n.isChaiAssert(node)) {
+          arg = obj.get(node, "parent.arguments.0");
+          if (!arg) {
+            return context.report(node, emptyArgMessage);
+          }
+          if (arg.type === "BinaryExpression") {
+            return checkBinaryInAssert(arg, node);
+          }
+          if (typesToReportAsDefault.indexOf(arg.type) !== -1 && !dontReport(arg)) {
+            return context.report(node, defaultMessage);
+          }
+        }
+      }
+    };
+  },
+
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-];
+}

--- a/lib/rules/no-nested-it.js
+++ b/lib/rules/no-nested-it.js
@@ -12,45 +12,50 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var insideIt = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var insideIt = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
 
-  function fEnter (node) {
-    if (n.isTestBody(node)) {
-      if (insideIt && !(skipSkipped && n.tryDetectSkipInParent(node))) {
-        context.report(node.parent, "Nested tests are not allowed. Only nested suites are allowed.");
-      }
-      else {
-        insideIt = true;
+    function fEnter (node) {
+      if (n.isTestBody(node)) {
+        if (insideIt && !(skipSkipped && n.tryDetectSkipInParent(node))) {
+          context.report(node.parent, "Nested tests are not allowed. Only nested suites are allowed.");
+        }
+        else {
+          insideIt = true;
+        }
       }
     }
-  }
 
-  function fExit (node) {
-    if (n.isTestBody(node)) {
-      insideIt = false;
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit
-  };
-};
-
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+    function fExit (node) {
+      if (n.isTestBody(node)) {
+        insideIt = false;
       }
-    },
-    additionalProperties: false
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit
+    };
+  },
+
+  meta: {
+    type: "problem",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-];
+}

--- a/lib/rules/no-outside-declaration.js
+++ b/lib/rules/no-outside-declaration.js
@@ -12,50 +12,55 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var insideSuite = false;
-  var insideHookOrTest = false;
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var m = "Variable declaration is not allowed outside tests and hooks.";
+    var insideSuite = false;
+    var insideHookOrTest = false;
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var m = "Variable declaration is not allowed outside tests and hooks.";
 
-  function fEnter (node) {
-    if (n.isSuiteBody(node) && !insideSuite) {
-      insideSuite = true;
-    }
-    if (n.isTestBody(node) || n.isHookBody(node)) {
-      insideHookOrTest = true;
-    }
-  }
-
-  function fExit (node) {
-    if (n.isTestBody(node) || n.isHookBody(node)) {
-      insideHookOrTest = false;
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "VariableDeclaration": function (node) {
-      if (insideSuite && !insideHookOrTest && !(skipSkipped && n.tryDetectSkipInParent(node))) {
-        context.report(node, m);
+    function fEnter (node) {
+      if (n.isSuiteBody(node) && !insideSuite) {
+        insideSuite = true;
+      }
+      if (n.isTestBody(node) || n.isHookBody(node)) {
+        insideHookOrTest = true;
       }
     }
-  };
-};
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      skipSkipped: {
-        type: "boolean"
+    function fExit (node) {
+      if (n.isTestBody(node) || n.isHookBody(node)) {
+        insideHookOrTest = false;
       }
-    },
-    additionalProperties: false
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "VariableDeclaration": function (node) {
+        if (insideSuite && !insideHookOrTest && !(skipSkipped && n.tryDetectSkipInParent(node))) {
+          context.report(node, m);
+        }
+      }
+    };
+  },
+
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-];
+}

--- a/lib/rules/no-same-titles.js
+++ b/lib/rules/no-same-titles.js
@@ -14,94 +14,99 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function (context) {
+module.exports = {
+  create: function (context) {
 
-  var insideSuite = false;
-  var testTitles = [];
-  var options = context.options[0] || {};
-  var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
-  var scope = hasOwnProperty.call(options, "scope") ? options.scope : "suite";
-  var checkNesting = scope === "suite";
-  var nestingLevel = checkNesting ? -1 : 0;
+    var insideSuite = false;
+    var testTitles = [];
+    var options = context.options[0] || {};
+    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var scope = hasOwnProperty.call(options, "scope") ? options.scope : "suite";
+    var checkNesting = scope === "suite";
+    var nestingLevel = checkNesting ? -1 : 0;
 
-  function report(level) {
-    Object.keys(testTitles[level]).forEach(function (title) {
-      if (testTitles[level][title].length > 1) {
-        testTitles[level][title].forEach(function(node) {
-          context.report(node, "Some tests have same titles.");
-        });
-      }
-    });
-  }
-
-  function fEnter (node) {
-    if (n.isSuiteBody(node) && !(skipSkipped && n.tryDetectSkipInParent(node))) {
-      insideSuite = true;
-      if (checkNesting) {
-        nestingLevel++;
-      }
-      if (!testTitles[nestingLevel]) {
-        testTitles[nestingLevel] = {};
-      }
-    }
-  }
-
-  function fExit (node) {
-    if (n.isSuiteBody(node) && !(skipSkipped && n.tryDetectSkipInParent(node))) {
-      insideSuite = false;
-      if (checkNesting) {
-        report(nestingLevel);
-        testTitles[nestingLevel] = {};
-        nestingLevel--;
-      }
-    }
-  }
-
-  return {
-    "FunctionExpression": fEnter,
-    "ArrowFunctionExpression": fEnter,
-    "FunctionExpression:exit": fExit,
-    "ArrowFunctionExpression:exit": fExit,
-    "CallExpression": function (node) {
-      if (insideSuite && !(skipSkipped && n.tryDetectSkipInParent(node)) && mocha.tests.indexOf(obj.get(node, "callee.name")) !== -1) {
-        var firstArgType = obj.get(node, "arguments.0.type");
-        if (firstArgType === "Literal") {
-          var title = obj.get(node, "arguments.0.value");
-          if (!Array.isArray(testTitles[nestingLevel][title])) { // title = "constructor" may break `!testTitles[nestingLevel][title]`
-            testTitles[nestingLevel][title] = [];
-          }
-          testTitles[nestingLevel][title].push(node);
+    function report(level) {
+      Object.keys(testTitles[level]).forEach(function (title) {
+        if (testTitles[level][title].length > 1) {
+          testTitles[level][title].forEach(function(node) {
+            context.report(node, "Some tests have same titles.");
+          });
         }
-      }
-    },
-    "Program:exit": function () {
-      if (checkNesting) {
-        return;
-      }
-      testTitles.forEach(function (level) {
-        Object.keys(level).forEach(function (title) {
-          if (level[title].length > 1) {
-            level[title].forEach(function(node) {
-              context.report(node, "Some tests have same titles.");
-            });
-          }
-        });
       });
     }
-  };
-};
 
-module.exports.schema = [
-  {
-    type: "object",
-    properties: {
-      scope: {
-        enum: ["suite", "file"]
-      },
-      skipSkipped: {
-        type: "boolean"
+    function fEnter (node) {
+      if (n.isSuiteBody(node) && !(skipSkipped && n.tryDetectSkipInParent(node))) {
+        insideSuite = true;
+        if (checkNesting) {
+          nestingLevel++;
+        }
+        if (!testTitles[nestingLevel]) {
+          testTitles[nestingLevel] = {};
+        }
       }
-    },
-    additionalProperties: false
+    }
+
+    function fExit (node) {
+      if (n.isSuiteBody(node) && !(skipSkipped && n.tryDetectSkipInParent(node))) {
+        insideSuite = false;
+        if (checkNesting) {
+          report(nestingLevel);
+          testTitles[nestingLevel] = {};
+          nestingLevel--;
+        }
+      }
+    }
+
+    return {
+      "FunctionExpression": fEnter,
+      "ArrowFunctionExpression": fEnter,
+      "FunctionExpression:exit": fExit,
+      "ArrowFunctionExpression:exit": fExit,
+      "CallExpression": function (node) {
+        if (insideSuite && !(skipSkipped && n.tryDetectSkipInParent(node)) && mocha.tests.indexOf(obj.get(node, "callee.name")) !== -1) {
+          var firstArgType = obj.get(node, "arguments.0.type");
+          if (firstArgType === "Literal") {
+            var title = obj.get(node, "arguments.0.value");
+            if (!Array.isArray(testTitles[nestingLevel][title])) { // title = "constructor" may break `!testTitles[nestingLevel][title]`
+              testTitles[nestingLevel][title] = [];
+            }
+            testTitles[nestingLevel][title].push(node);
+          }
+        }
+      },
+      "Program:exit": function () {
+        if (checkNesting) {
+          return;
+        }
+        testTitles.forEach(function (level) {
+          Object.keys(level).forEach(function (title) {
+            if (level[title].length > 1) {
+              level[title].forEach(function(node) {
+                context.report(node, "Some tests have same titles.");
+              });
+            }
+          });
+        });
+      }
+    };
+  },
+
+  meta: {
+    type: "suggestion",
+    schema: [
+      {
+        type: "object",
+        properties: {
+          scope: {
+            enum: ["suite", "file"]
+          },
+          skipSkipped: {
+            type: "boolean"
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   }
-];
+}


### PR DESCRIPTION
- Update: Switch to non-deprecated rule format; see https://eslint.org/blog/2016/07/eslint-new-rule-format

I've also added `type: "suggestion"` or `type: "problem"` as I thought appropriate, though please let me know if you think any of these ought to change. These options are described at https://eslint.org/docs/developer-guide/working-with-rules#rule-basics