### PR TITLE
Skip skipped setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install eslint-plugin-mocha-cleanup --save-dev
 
 ## Supported Rules
 
-Almost each rule (unless otherwise indicated) may be customized to ignore skipped tests/suites (`describe.skip`, `it.skip`, `xspecify` etc) with adding `skipSkipped: true` to the rule-options.
+Almost each rule (unless otherwise indicated) may be customized to ignore skipped tests/suites (`describe.skip`, `it.skip`, `xspecify` etc) with adding `skipSkipped: true` to the rule-options. One can also set `"settings": {"mocha-cleanup": {"skipSkipped": true}}` to have skipping for all applicable rules by default.
 
 * `asserts-limit` Rule to disallow use more than allowed number of assertions. Tests without any assertions are also disallowed. Rule may be customized with setting maximum number of allowed asserts (Defaults to 3):
 
@@ -95,7 +95,7 @@ This rule ignores tests with `done`-callback and 0 assertions. Set option `ignor
 }
 ```
 
-* `disallow-stub-window` Rule to disallow stubbing some `window`-methods. **IMPORTANT** This rule doesn't have `skipSkipped` option
+* `disallow-stub-window` Rule to disallow stubbing some `window`-methods. **IMPORTANT** This rule doesn't have a `skipSkipped` option
 
 * `no-outside-declaration` Rule to disallow variables declaration outside tests and hooks
 

--- a/lib/rules/asserts-limit.js
+++ b/lib/rules/asserts-limit.js
@@ -7,6 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -20,7 +21,7 @@ module.exports = {
     var assertsCounter = 0;
     var options = context.options[0] || {};
     var assertsLimit = options.assertsLimit >= 1 ? options.assertsLimit : 3;
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var ignoreZeroAssertionsIfDoneExists = hasOwnProperty.call(options, "ignoreZeroAssertionsIfDoneExists") ? options.ignoreZeroAssertionsIfDoneExists : true;
     var nodeSkipped;
     var doneExists;

--- a/lib/rules/complexity-it.js
+++ b/lib/rules/complexity-it.js
@@ -8,6 +8,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 //------------------------------------------------------------------------------
@@ -21,7 +22,7 @@ module.exports = {
     var currentComplexityCount = 0;
     var options = context.options[0] || {};
     var maxAllowedComplexity = hasOwnProperty.call(options, "maxAllowedComplexity") ? options.maxAllowedComplexity : 40;
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped;
 
     function increaseComplexity() {

--- a/lib/rules/disallow-stub-spy-restore-in-it.js
+++ b/lib/rules/disallow-stub-spy-restore-in-it.js
@@ -8,7 +8,7 @@
 
 var obj = require("../utils/obj.js");
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ module.exports = {
     var disallowed = ["stub", "spy", "restore"];
     var insideTest = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped = false;
     var caller = "";
 

--- a/lib/rules/disallowed-usage.js
+++ b/lib/rules/disallowed-usage.js
@@ -8,6 +8,7 @@
 
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -50,7 +51,7 @@ module.exports = {
     var insideTest = false;
     var insideHook = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var disallowedMethodsInTests = hasOwnProperty.call(options, "test") ? prepareCallers(options.test) : [];
     var disallowedPropertiesInTests = hasOwnProperty.call(options, "test") ? prepareProperties(options.test) : [];
     var disallowedMethodsInHooks = hasOwnProperty.call(options, "hook") ? prepareCallers(options.hook) : [];

--- a/lib/rules/invalid-assertions.js
+++ b/lib/rules/invalid-assertions.js
@@ -7,7 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
     var m = "Invalid assertion usage.";
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped;
 
     function check(node) {

--- a/lib/rules/no-assertions-in-loop.js
+++ b/lib/rules/no-assertions-in-loop.js
@@ -7,6 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +18,7 @@ module.exports = {
     var loopStatements = ["WhileStatement", "DoWhileStatement", "ForStatement", "ForInStatement", "ForOfStatement"];
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var extraMemberExpression = hasOwnProperty.call(options, "extraMemberExpression") ? options.extraMemberExpression : [];
     var nodeSkipped;
 

--- a/lib/rules/no-assertions-outside-it.js
+++ b/lib/rules/no-assertions-outside-it.js
@@ -9,7 +9,7 @@
 var n = require("../utils/node.js");
 var m = require("../utils/mocha-specs.js");
 var obj = require("../utils/obj.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ module.exports = {
 
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     var message = "Assertion outside tests is not allowed.";
 

--- a/lib/rules/no-empty-body.js
+++ b/lib/rules/no-empty-body.js
@@ -9,7 +9,7 @@
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
 var mocha = require("../utils/mocha-specs.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var toCheck = mocha.all.concat(mocha.hooks);
 
 //------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ var toCheck = mocha.all.concat(mocha.hooks);
 module.exports = {
   create: function (context) {
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     function fEnter (node) {
       if (skipSkipped && n.tryDetectSkipInParent(node)) {

--- a/lib/rules/no-empty-title.js
+++ b/lib/rules/no-empty-title.js
@@ -9,7 +9,7 @@
 var obj = require("../utils/obj.js");
 var n = require("../utils/node.js");
 var mocha = require("../utils/mocha-specs.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ module.exports = {
   create: function (context) {
 
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     return {
       "CallExpression": function (node) {

--- a/lib/rules/no-eql-primitives.js
+++ b/lib/rules/no-eql-primitives.js
@@ -8,7 +8,7 @@
 
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
   create: function (context) {
 
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var strictCheck = ["assert.deepEqual", "assert.notDeepEqual"];
     var notStrictCheck = [".eql", ".deep.equal"];
     var insideTest = false;

--- a/lib/rules/no-expressions-in-assertions.js
+++ b/lib/rules/no-expressions-in-assertions.js
@@ -8,7 +8,7 @@
 
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
   create: function (context) {
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped;
 
     var defaultMessage = "Expression should not be used here.";

--- a/lib/rules/no-nested-it.js
+++ b/lib/rules/no-nested-it.js
@@ -7,7 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
 
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     function fEnter (node) {
       if (n.isTestBody(node)) {

--- a/lib/rules/no-outside-declaration.js
+++ b/lib/rules/no-outside-declaration.js
@@ -7,7 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ module.exports = {
     var insideSuite = false;
     var insideHookOrTest = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var m = "Variable declaration is not allowed outside tests and hooks.";
 
     function fEnter (node) {

--- a/lib/rules/no-same-titles.js
+++ b/lib/rules/no-same-titles.js
@@ -9,6 +9,7 @@
 var obj = require("../utils/obj.js");
 var n = require("../utils/node.js");
 var mocha = require("../utils/mocha-specs.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -20,7 +21,7 @@ module.exports = {
     var insideSuite = false;
     var testTitles = [];
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var scope = hasOwnProperty.call(options, "scope") ? options.scope : "suite";
     var checkNesting = scope === "suite";
     var nestingLevel = checkNesting ? -1 : 0;

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -1,0 +1,9 @@
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+var obj = require("./obj.js");
+
+exports.isSkipSkipped = function (options, context) {
+  return hasOwnProperty.call(options, "skipSkipped")
+    ? options.skipSkipped
+    : obj.get(context, "settings.mocha-cleanup.skipSkipped") || false;
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "test": "eslint . && mocha -R min tests/lib/rules",
+    "eslint": "eslint .",
+    "test": "npm run eslint && mocha -R min tests/lib/rules",
     "test:fast": "mocha -R min tests/lib/rules --fast"
   },
   "dependencies": {

--- a/tests/lib/rules/asserts-limit.js
+++ b/tests/lib/rules/asserts-limit.js
@@ -95,6 +95,17 @@ var validTestTemplates = [
     {
       code:
         "{{SUITESKIP}}('1234', {{ES}} " +
+          "{{TEST}}('1234', {{ES}}" +
+            "{{ASSERTION}} {{ASSERTION}} {{ASSERTION}}" +
+          "});" +
+         "});",
+      settings: {"mocha-cleanup": {"skipSkipped": true}},
+      options: [{assertsLimit: 1}],
+      errors: [{message: "Too many assertions (3). Maximum allowed is 2."}]
+    },
+    {
+      code:
+        "{{SUITESKIP}}('1234', {{ES}} " +
           "{{SUITE}}('4321', {{ES}} " +
             "{{TEST}}('1234', {{ES}}" +
               "{{ASSERTION}} {{ASSERTION}} {{ASSERTION}}" +


### PR DESCRIPTION
~Builds on #13.~

- Enhancement: Add `settings.mocha-cleanup.skipSkipped` for default behavior across rules
- npm: Create separate script for linting
