### PR TITLE
No expressions in assertions option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,10 @@
   "rules": {
     "quotes": [2, "double"]
   },
+  "overrides": [{
+    "files": "tests/lib/utils/**",
+    "env": {"mocha": true}
+  }],
   "env": {
     "browser": true,
     "node": true

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
 tests
+.nyc_output
+.ncurc.js

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ $ npm install eslint-plugin-mocha-cleanup --save-dev
 
 ## Supported Rules
 
-Almost each rule (unless otherwise indicated) may be customized to ignore skipped tests/suites (`describe.skip`, `it.skip`, `xspecify` etc) with adding `skipSkipped: true` to the rule-options. One can also set `"settings": {"mocha-cleanup": {"skipSkipped": true}}` to have skipping for all applicable rules by default.
+Almost each rule (unless otherwise indicated) may be customized to ignore skipped tests/suites (`describe.skip`, `it.skip`, `xspecify`, etc.) by adding `skipSkipped: true` to the rule options. One can also set `"settings": {"mocha-cleanup": {"skipSkipped": true}}` to have skipping for all applicable rules by default.
 
-* `asserts-limit` Rule to disallow use more than allowed number of assertions. Tests without any assertions are also disallowed. Rule may be customized with setting maximum number of allowed asserts (Defaults to 3):
+* `asserts-limit` Rule to disallow use of more than an allowed number of assertions. Tests without any assertions are also disallowed. Rule may be customized with setting the maximum number of allowed asserts (Defaults to 3):
 
 ```json
 "rules": {
@@ -33,7 +33,7 @@ Almost each rule (unless otherwise indicated) may be customized to ignore skippe
 }
 ```
 
-This rule ignores tests with `done`-callback and 0 assertions. Set option `ignoreZeroAssertionsIfDoneExists` to `false` to allow such behavior:
+This rule ignores tests with a `done`-callback and 0 assertions. Set the option `ignoreZeroAssertionsIfDoneExists` to `false` to allow such behavior:
 
 ```json
 "rules": {
@@ -41,11 +41,11 @@ This rule ignores tests with `done`-callback and 0 assertions. Set option `ignor
 }
 ```
 
-* `disallow-stub-spy-restore-in-it` Rule to disallow `stub/spy/restore` in the tests (should be in the hooks)
+* `disallow-stub-spy-restore-in-it` Rule to disallow `stub/spy/restore` in tests (they should instead be in hooks)
 
-* `no-empty-title` Rule to disallow empty title in the suites and tests
+* `no-empty-title` Rule to disallow empty titles in suites and tests
 
-* `no-same-titles` Rule to disallow same titles for tests inside one suite or in the whole file. It depends on `scope` value - may be `file` or `suite`. Default - `suite`
+* `no-same-titles` Rule to disallow identical titles for tests inside of one suite or within the whole file. It depends on the `scope` value - may be `file` or `suite`. Defaults to `suite`
 
 ```json
 "rules": {
@@ -79,9 +79,9 @@ This rule ignores tests with `done`-callback and 0 assertions. Set option `ignor
 
 * `invalid-assertions` Rule to check `expect` and `should` assertions for completeness. It detects assertions that end with "chainable" words or even raw calls for `expect` and `should`
 
-* `no-expressions-in-assertions` Rule to detect expressions in the `expect` and `assert` assertions
+* `no-expressions-in-assertions` Rule to detect expressions in `expect` and `assert` assertions
 
-* `disallowed-usage` Rule to disallow usage some functions, methods or properties in the tests and hooks
+* `disallowed-usage` Rule to disallow usage of some functions, methods or properties in the tests and hooks
 
 ```json
 "rules": {
@@ -97,7 +97,7 @@ This rule ignores tests with `done`-callback and 0 assertions. Set option `ignor
 
 * `disallow-stub-window` Rule to disallow stubbing some `window`-methods. **IMPORTANT** This rule doesn't have a `skipSkipped` option
 
-* `no-outside-declaration` Rule to disallow variables declaration outside tests and hooks
+* `no-outside-declaration` Rule to disallow variable declarations outside tests and hooks
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install eslint-plugin-mocha-cleanup --save-dev
 
 ## Supported Rules
 
-Almost each rule (unless otherwise indicated) may be customized to ignore skipped tests/suites (`describe.skip`, `it.skip`, `xspecify` etc) with adding `skipSkipped: true` to the rule-options.
+Almost each rule (unless otherwise indicated) may be customized to ignore skipped tests/suites (`describe.skip`, `it.skip`, `xspecify` etc) with adding `skipSkipped: true` to the rule-options. One can also set `"settings": {"mocha-cleanup": {"skipSkipped": true}}` to have skipping for all applicable rules by default.
 
 * `asserts-limit` Rule to disallow use more than allowed number of assertions. Tests without any assertions are also disallowed. Rule may be customized with setting maximum number of allowed asserts (Defaults to 3):
 
@@ -95,7 +95,7 @@ This rule ignores tests with `done`-callback and 0 assertions. Set option `ignor
 }
 ```
 
-* `disallow-stub-window` Rule to disallow stubbing some `window`-methods. **IMPORTANT** This rule doesn't have `skipSkipped` option
+* `disallow-stub-window` Rule to disallow stubbing some `window`-methods. **IMPORTANT** This rule doesn't have a `skipSkipped` option
 
 * `no-outside-declaration` Rule to disallow variables declaration outside tests and hooks
 

--- a/lib/rules/asserts-limit.js
+++ b/lib/rules/asserts-limit.js
@@ -7,6 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -20,7 +21,7 @@ module.exports = {
     var assertsCounter = 0;
     var options = context.options[0] || {};
     var assertsLimit = options.assertsLimit >= 1 ? options.assertsLimit : 3;
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var ignoreZeroAssertionsIfDoneExists = hasOwnProperty.call(options, "ignoreZeroAssertionsIfDoneExists") ? options.ignoreZeroAssertionsIfDoneExists : true;
     var nodeSkipped;
     var doneExists;

--- a/lib/rules/complexity-it.js
+++ b/lib/rules/complexity-it.js
@@ -8,6 +8,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 //------------------------------------------------------------------------------
@@ -21,7 +22,7 @@ module.exports = {
     var currentComplexityCount = 0;
     var options = context.options[0] || {};
     var maxAllowedComplexity = hasOwnProperty.call(options, "maxAllowedComplexity") ? options.maxAllowedComplexity : 40;
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped;
 
     function increaseComplexity() {

--- a/lib/rules/disallow-stub-spy-restore-in-it.js
+++ b/lib/rules/disallow-stub-spy-restore-in-it.js
@@ -8,7 +8,7 @@
 
 var obj = require("../utils/obj.js");
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ module.exports = {
     var disallowed = ["stub", "spy", "restore"];
     var insideTest = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped = false;
     var caller = "";
 

--- a/lib/rules/disallow-stub-spy-restore-in-it.js
+++ b/lib/rules/disallow-stub-spy-restore-in-it.js
@@ -47,13 +47,11 @@ module.exports = {
       "FunctionExpression:exit": fExit,
       "ArrowFunctionExpression:exit": fExit,
 
-      "CallExpression": function (node) {
+      "CallExpression[callee]": function (node) {
         var callee = obj.get(node, "callee");
-        if (callee) {
-          var _c = n.cleanCaller(n.getCaller(callee)).split(".").pop();
-          if (insideTest && disallowed.indexOf(_c) !== -1 && !nodeSkipped) {
-            context.report(node, "`{{name}}` is not allowed to use inside `{{caller}}`.", {name: _c, caller: caller});
-          }
+        var _c = n.cleanCaller(n.getCaller(callee)).split(".").pop();
+        if (insideTest && disallowed.indexOf(_c) !== -1 && !nodeSkipped) {
+          context.report(node, "`{{name}}` is not allowed to use inside `{{caller}}`.", {name: _c, caller: caller});
         }
       }
 

--- a/lib/rules/disallowed-usage.js
+++ b/lib/rules/disallowed-usage.js
@@ -8,6 +8,7 @@
 
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -50,7 +51,7 @@ module.exports = {
     var insideTest = false;
     var insideHook = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var disallowedMethodsInTests = hasOwnProperty.call(options, "test") ? prepareCallers(options.test) : [];
     var disallowedPropertiesInTests = hasOwnProperty.call(options, "test") ? prepareProperties(options.test) : [];
     var disallowedMethodsInHooks = hasOwnProperty.call(options, "hook") ? prepareCallers(options.hook) : [];

--- a/lib/rules/disallowed-usage.js
+++ b/lib/rules/disallowed-usage.js
@@ -50,7 +50,10 @@ module.exports = {
 
     var insideTest = false;
     var insideHook = false;
-    var options = context.options[0] || {};
+    var options = context.options[0];
+    if (!options) {
+      return {};
+    }
     var skipSkipped = isSkipSkipped(options, context);
     var disallowedMethodsInTests = hasOwnProperty.call(options, "test") ? prepareCallers(options.test) : [];
     var disallowedPropertiesInTests = hasOwnProperty.call(options, "test") ? prepareProperties(options.test) : [];
@@ -86,10 +89,12 @@ module.exports = {
       "ArrowFunctionExpression:exit": fExit,
       "CallExpression": function (node) {
         var parent = obj.get(node, "parent");
+        /* istanbul ignore if */
         if (!parent) {
           return;
         }
         var caller = n.cleanCaller(n.getCaller(node));
+        /* istanbul ignore if */
         if (!caller) {
           return;
         }
@@ -102,6 +107,7 @@ module.exports = {
       },
       "MemberExpression": function (node) {
         var parent = obj.get(node, "parent");
+        /* istanbul ignore if */
         if (!parent) {
           return;
         }

--- a/lib/rules/invalid-assertions.js
+++ b/lib/rules/invalid-assertions.js
@@ -26,10 +26,13 @@ module.exports = {
       }
       if (n.isAssertion(node)) {
         var parentExpression = n.getParentExpression(node);
+        /* istanbul ignore if */
         if (!parentExpression) {
           return;
         }
-        var caller = n.getCaller(parentExpression.expression) || "";
+        var caller = n.getCaller(parentExpression.expression) ||
+          /* istanbul ignore next */
+          "";
         if (["expect", "chai.expect"].indexOf(caller) !== -1) {
           return context.report(node, m);
         }

--- a/lib/rules/invalid-assertions.js
+++ b/lib/rules/invalid-assertions.js
@@ -7,7 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
     var m = "Invalid assertion usage.";
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped;
 
     function check(node) {

--- a/lib/rules/no-assertions-in-loop.js
+++ b/lib/rules/no-assertions-in-loop.js
@@ -7,6 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +18,7 @@ module.exports = {
     var loopStatements = ["WhileStatement", "DoWhileStatement", "ForStatement", "ForInStatement", "ForOfStatement"];
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var extraMemberExpression = hasOwnProperty.call(options, "extraMemberExpression") ? options.extraMemberExpression : [];
     var nodeSkipped;
 

--- a/lib/rules/no-assertions-in-loop.js
+++ b/lib/rules/no-assertions-in-loop.js
@@ -23,6 +23,7 @@ module.exports = {
     var nodeSkipped;
 
     function detectParentLoopInTest(node) {
+      /* istanbul ignore if */
       if (!node) {
         return false;
       }

--- a/lib/rules/no-assertions-outside-it.js
+++ b/lib/rules/no-assertions-outside-it.js
@@ -9,7 +9,7 @@
 var n = require("../utils/node.js");
 var m = require("../utils/mocha-specs.js");
 var obj = require("../utils/obj.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ module.exports = {
 
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     var message = "Assertion outside tests is not allowed.";
 

--- a/lib/rules/no-empty-body.js
+++ b/lib/rules/no-empty-body.js
@@ -9,7 +9,7 @@
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
 var mocha = require("../utils/mocha-specs.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var toCheck = mocha.all.concat(mocha.hooks);
 
 //------------------------------------------------------------------------------
@@ -19,7 +19,7 @@ var toCheck = mocha.all.concat(mocha.hooks);
 module.exports = {
   create: function (context) {
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     function fEnter (node) {
       if (skipSkipped && n.tryDetectSkipInParent(node)) {

--- a/lib/rules/no-empty-title.js
+++ b/lib/rules/no-empty-title.js
@@ -9,7 +9,7 @@
 var obj = require("../utils/obj.js");
 var n = require("../utils/node.js");
 var mocha = require("../utils/mocha-specs.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ module.exports = {
   create: function (context) {
 
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     return {
       "CallExpression": function (node) {

--- a/lib/rules/no-eql-primitives.js
+++ b/lib/rules/no-eql-primitives.js
@@ -47,6 +47,7 @@ module.exports = {
       "MemberExpression": function (node) {
         if (insideTest && !(skipSkipped && n.tryDetectSkipInParent(node))) {
           var caller = n.getCaller(node);
+          /* istanbul ignore if */
           if (!caller) {
             return;
           }

--- a/lib/rules/no-eql-primitives.js
+++ b/lib/rules/no-eql-primitives.js
@@ -8,7 +8,7 @@
 
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
   create: function (context) {
 
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var strictCheck = ["assert.deepEqual", "assert.notDeepEqual"];
     var notStrictCheck = [".eql", ".deep.equal"];
     var insideTest = false;

--- a/lib/rules/no-expressions-in-assertions.js
+++ b/lib/rules/no-expressions-in-assertions.js
@@ -165,7 +165,7 @@ module.exports = {
      * @returns {boolean}
      */
     function checkForUndefinedAssert(binaryExpression, op, node) {
-      var shouldUse = op[0] === "!" ? ".isUndefined" : ".isDefined";
+      var shouldUse = op[0] === "!" ? ".isDefined" : ".isUndefined";
       if (obj.get(binaryExpression, "left.name") === "undefined" || obj.get(binaryExpression, "right.name") === "undefined") {
         context.report(node, detailedMessage, {shouldUse: shouldUse});
         return true;

--- a/lib/rules/no-expressions-in-assertions.js
+++ b/lib/rules/no-expressions-in-assertions.js
@@ -19,6 +19,7 @@ module.exports = {
     var options = context.options[0] || {};
     var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped;
+    var replacementsOnly = options.replacementsOnly;
 
     var defaultMessage = "Expression should not be used here.";
     var detailedMessage = "`{{shouldUse}}` should be used.";
@@ -75,7 +76,9 @@ module.exports = {
         }
         return context.report(node, detailedMessage, {shouldUse: shouldUse});
       }
-      return context.report(node, defaultMessage);
+      if (!replacementsOnly) {
+        return context.report(node, defaultMessage);
+      }
     }
 
     /**
@@ -136,7 +139,9 @@ module.exports = {
         }
         return context.report(node, detailedMessage, {shouldUse: shouldUse});
       }
-      return context.report(node, defaultMessage);
+      if (!replacementsOnly) {
+        return context.report(node, defaultMessage);
+      }
     }
 
     /**
@@ -190,7 +195,7 @@ module.exports = {
     }
 
     function dontReport(arg) {
-      return arg.operator === "typeof";
+      return replacementsOnly || arg.operator === "typeof";
     }
 
     return {
@@ -258,6 +263,9 @@ module.exports = {
         type: "object",
         properties: {
           skipSkipped: {
+            type: "boolean"
+          },
+          replacementsOnly: {
             type: "boolean"
           }
         },

--- a/lib/rules/no-expressions-in-assertions.js
+++ b/lib/rules/no-expressions-in-assertions.js
@@ -8,7 +8,7 @@
 
 var n = require("../utils/node.js");
 var obj = require("../utils/obj.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
   create: function (context) {
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var nodeSkipped;
 
     var defaultMessage = "Expression should not be used here.";

--- a/lib/rules/no-nested-it.js
+++ b/lib/rules/no-nested-it.js
@@ -7,7 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ module.exports = {
 
     var insideIt = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
 
     function fEnter (node) {
       if (n.isTestBody(node)) {

--- a/lib/rules/no-outside-declaration.js
+++ b/lib/rules/no-outside-declaration.js
@@ -7,7 +7,7 @@
 "use strict";
 
 var n = require("../utils/node.js");
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -18,7 +18,7 @@ module.exports = {
     var insideSuite = false;
     var insideHookOrTest = false;
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var m = "Variable declaration is not allowed outside tests and hooks.";
 
     function fEnter (node) {

--- a/lib/rules/no-same-titles.js
+++ b/lib/rules/no-same-titles.js
@@ -9,6 +9,7 @@
 var obj = require("../utils/obj.js");
 var n = require("../utils/node.js");
 var mocha = require("../utils/mocha-specs.js");
+var isSkipSkipped = require("../utils/options.js").isSkipSkipped;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -20,7 +21,7 @@ module.exports = {
     var insideSuite = false;
     var testTitles = [];
     var options = context.options[0] || {};
-    var skipSkipped = hasOwnProperty.call(options, "skipSkipped") ? options.skipSkipped : false;
+    var skipSkipped = isSkipSkipped(options, context);
     var scope = hasOwnProperty.call(options, "scope") ? options.scope : "suite";
     var checkNesting = scope === "suite";
     var nestingLevel = checkNesting ? -1 : 0;

--- a/lib/utils/node.js
+++ b/lib/utils/node.js
@@ -131,6 +131,7 @@ function isChaiAssert(node) {
  * @returns {boolean}
  */
 function isBlockBody(node, type) {
+  /* istanbul ignore next */
   var types = Array.isArray(type) ? type : [type];
   var parent = node.parent;
   if (!parent) {
@@ -140,9 +141,12 @@ function isBlockBody(node, type) {
   if (parentType === "MemberExpression") {
     return types.indexOf(parent.callee.object.name + "." + parent.callee.property.name) !== -1 && obj.get(parent, "arguments.1") === node;
   }
+  /* istanbul ignore else */
   if (parentType === "Identifier") {
     return types.indexOf(obj.get(parent, "callee.name")) !== -1 && (obj.get(parent, "arguments.0") === node || obj.get(parent, "arguments.1") === node);
   }
+
+  /* istanbul ignore next */
   return false;
 }
 

--- a/lib/utils/obj.js
+++ b/lib/utils/obj.js
@@ -40,7 +40,9 @@ module.exports = {
   },
 
   getType: function (value) {
-    return _typesMap[{}.toString.call(value)] || "object";
+    return _typesMap[{}.toString.call(value)] ||
+      /* istanbul ignore next */
+      "object";
   }
 
 };

--- a/lib/utils/options.js
+++ b/lib/utils/options.js
@@ -1,0 +1,9 @@
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
+var obj = require("./obj.js");
+
+exports.isSkipSkipped = function (options, context) {
+  return hasOwnProperty.call(options, "skipSkipped")
+    ? options.skipSkipped
+    : obj.get(context, "settings.mocha-cleanup.skipSkipped") || false;
+};

--- a/lib/utils/tests.js
+++ b/lib/utils/tests.js
@@ -24,7 +24,10 @@ var hooks = [
 ];
 
 module.exports = {
-  mochaDatasets: fast ? combos[0] : combos,
+  mochaDatasets: fast
+    /* istanbul ignore next */
+    ? combos[0]
+    : combos,
   es: es,
   hooks: hooks
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,89 @@
         "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/core": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.4.tgz",
+      "integrity": "sha512-0LiLrB2PwrVI+a2/IEskBopDYSd8BCb3rOvH7D5tzoWd696TBEduBvuLVm4Nx6rltrLZqvI3MCalB2K2aVzQjA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helpers": "^7.8.4",
+        "@babel/parser": "^7.8.4",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
+      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.4",
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/highlight": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
@@ -23,6 +106,125 @@
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@babel/parser": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.8.4",
+        "@babel/types": "^7.8.3",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "acorn": {
       "version": "7.1.0",
@@ -35,6 +237,16 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
       "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
       "dev": true
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
     },
     "ajv": {
       "version": "6.12.0",
@@ -88,6 +300,21 @@
         "picomatch": "^2.0.4"
       }
     },
+    "append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^3.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -140,6 +367,18 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "requires": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -184,6 +423,12 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -251,11 +496,26 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -298,6 +558,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^4.0.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -358,6 +627,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -538,6 +813,17 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-cache-dir": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
+      "integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -573,6 +859,65 @@
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
+    "foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "fromentries": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
+      "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -596,6 +941,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
       "dev": true
     },
     "get-caller-file": {
@@ -636,6 +987,12 @@
         "type-fest": "^0.8.1"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -663,10 +1020,26 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "hasha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+      "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
       "dev": true
     },
     "iconv-lite": {
@@ -698,6 +1071,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -806,6 +1185,12 @@
         "has": "^1.0.3"
       }
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -815,11 +1200,177 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^2.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
+      "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+      "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -837,6 +1388,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -848,6 +1405,23 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json5": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "jsonium": {
       "version": "1.5.0",
@@ -881,6 +1455,12 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -888,6 +1468,15 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
+      }
+    },
+    "make-dir": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
+      "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
       }
     },
     "mimic-fn": {
@@ -1040,11 +1629,192 @@
         }
       }
     },
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "nyc": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
+      "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.0",
+        "js-yaml": "^3.13.1",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.0",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "uuid": "^3.3.3",
+        "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
+          "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^16.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -1136,11 +1906,32 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -1169,17 +1960,77 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
     },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
     },
     "progress": {
       "version": "2.0.3",
@@ -1208,6 +2059,15 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1224,6 +2084,15 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww=="
+    },
+    "resolve": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -1267,6 +2136,12 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -1323,6 +2198,46 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -1391,6 +2306,12 @@
         }
       }
     },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -1443,6 +2364,17 @@
         }
       }
     },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1463,6 +2395,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -1494,6 +2432,15 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -1502,6 +2449,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.0",
@@ -1621,6 +2574,18 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "main": "lib/index.js",
   "scripts": {
     "eslint": "eslint .",
-    "test": "npm run eslint && nyc mocha -R min tests/lib/rules",
-    "test:fast": "mocha -R min tests/lib/rules --fast"
+    "test": "npm run eslint && nyc mocha -R min tests/lib/**",
+    "test:fast": "mocha -R min tests/lib/** --fast"
   },
   "dependencies": {
     "requireindex": "~1.2.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "lib/index.js",
   "scripts": {
     "eslint": "eslint .",
-    "test": "npm run eslint && mocha -R min tests/lib/rules",
+    "test": "npm run eslint && nyc mocha -R min tests/lib/rules",
     "test:fast": "mocha -R min tests/lib/rules --fast"
   },
   "dependencies": {
@@ -28,7 +28,8 @@
   "devDependencies": {
     "eslint": "~6.8.0",
     "jsonium": "^1.5.0",
-    "mocha": ">=7.0.1"
+    "mocha": ">=7.0.1",
+    "nyc": "^15.0.0"
   },
   "peerDependencies": {
     "eslint": ">=0.8.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "main": "lib/index.js",
   "scripts": {
-    "test": "eslint . && mocha -R min tests/lib/rules",
+    "eslint": "eslint .",
+    "test": "npm run eslint && mocha -R min tests/lib/rules",
     "test:fast": "mocha -R min tests/lib/rules --fast"
   },
   "dependencies": {

--- a/tests/lib/rules/asserts-limit.js
+++ b/tests/lib/rules/asserts-limit.js
@@ -95,6 +95,17 @@ var validTestTemplates = [
     {
       code:
         "{{SUITESKIP}}('1234', {{ES}} " +
+          "{{TEST}}('1234', {{ES}}" +
+            "{{ASSERTION}} {{ASSERTION}} {{ASSERTION}}" +
+          "});" +
+         "});",
+      settings: {"mocha-cleanup": {"skipSkipped": true}},
+      options: [{assertsLimit: 1}],
+      errors: [{message: "Too many assertions (3). Maximum allowed is 2."}]
+    },
+    {
+      code:
+        "{{SUITESKIP}}('1234', {{ES}} " +
           "{{SUITE}}('4321', {{ES}} " +
             "{{TEST}}('1234', {{ES}}" +
               "{{ASSERTION}} {{ASSERTION}} {{ASSERTION}}" +

--- a/tests/lib/rules/complexity-it.js
+++ b/tests/lib/rules/complexity-it.js
@@ -26,6 +26,16 @@ var validTestTemplates = [
           "var expected = myTestCase.expected[0];" +
           "expect(result).to.be.equal(expected);" +
         "});" +
+      "});"
+  },
+  {
+    code:
+      "{{SUITE}}('3421', {{ES}}" +
+        "{{TEST}}('1234', {{ES}}" +
+          "var result = myObj.mySubObj.coolFunc(1, 2);" +
+          "var expected = myTestCase.expected[0];" +
+          "expect(result).to.be.equal(expected);" +
+        "});" +
       "});",
     options: [{maxAllowedComplexity: 6}]
   },

--- a/tests/lib/rules/disallow-stub-window.js
+++ b/tests/lib/rules/disallow-stub-window.js
@@ -146,6 +146,8 @@ var invalidTests = j
   .getCombos();
 
 ruleTester.run("disallow-stub-window", rule, {
-  valid: validTests,
+  valid: [
+    "stub(notWindow, 'setTimeout');"
+  ].concat(validTests),
   invalid: invalidTests
 });

--- a/tests/lib/rules/disallowed-usage.js
+++ b/tests/lib/rules/disallowed-usage.js
@@ -200,6 +200,8 @@ var invalidTests = j
   .getCombos();
 
 ruleTester.run("disallowed-usage", rule, {
-  valid: validTests,
+  valid: [
+    "ifNoOptionsJustIgnore;"
+  ].concat(validTests),
   invalid: invalidTests
 });

--- a/tests/lib/rules/invalid-assertions.js
+++ b/tests/lib/rules/invalid-assertions.js
@@ -102,6 +102,12 @@ var invalidTests = j
   .getCombos();
 
 ruleTester.run("invalid-assertions", rule, {
-  valid: validTests,
+  valid: [
+    "describe('1234', function () {" +
+      "it('4321', function () {" +
+        "return expect(1)" +
+      "})" +
+    "})"
+  ].concat(validTests),
   invalid: invalidTests
 });

--- a/tests/lib/rules/no-empty-body.js
+++ b/tests/lib/rules/no-empty-body.js
@@ -165,6 +165,8 @@ var invalidTests = j
 
 
 ruleTester.run("no-empty-body", rule, {
-  valid: validTests,
+  valid: [
+    "var a = function () {}"
+  ].concat(validTests),
   invalid: invalidTests
 });

--- a/tests/lib/rules/no-empty-title.js
+++ b/tests/lib/rules/no-empty-title.js
@@ -140,6 +140,10 @@ var invalidTests = j
 
 
 ruleTester.run("no-empty-title", rule, {
-  valid: validTests,
+  valid: [
+    "it('123', function () {" +
+      "abc['']();" +
+    "});"
+  ].concat(validTests),
   invalid: invalidTests
 });

--- a/tests/lib/rules/no-eql-primitives.js
+++ b/tests/lib/rules/no-eql-primitives.js
@@ -153,6 +153,30 @@ var invalidTests = j
   .getCombos();
 
 ruleTester.run("no-eql-primitives", rule, {
-  valid: validTests,
+  valid: [
+    {
+      // This type doesn't seem to get through the `valid` examples
+      //   above, though this is based on them
+      code:
+        "describe.skip('123', function () {" +
+          "it('123', function () {" +
+            "assert.deepEqual(a, 1)" +
+          "});" +
+        "});",
+      options: [{skipSkipped: true}]
+    },
+    "it('123', function () {" +
+      "abc[''];" +
+    "});",
+    "it('123', function () {" +
+      "abc.foo[''];" +
+    "});",
+    "it('123', function () {" +
+      "assert.deepEqual(a, /foo/);" +
+    "});",
+    "it('123', function () {" +
+      "expect(a).to.be.eql(/foo/);" +
+    "});"
+  ].concat(validTests),
   invalid: invalidTests
 });

--- a/tests/lib/rules/no-expressions-in-assertions.js
+++ b/tests/lib/rules/no-expressions-in-assertions.js
@@ -344,7 +344,37 @@ ruleTester.run("no-expressions-in-assertions", rule, {
       "test('123', function () {" +
         "assert.equal(`ok`);" +
       "});" +
-    "});"
+    "});",
+    {
+      code: "describe('123', function () {" +
+        "test('123', function () {" +
+          "assert.equal(a + b, 5);" +
+        "});" +
+      "});",
+      options: [
+        {replacementsOnly: true}
+      ]
+    },
+    {
+      code: "describe('123', function () {" +
+        "test('123', function () {" +
+          "expect(a + b).to.equal(5);" +
+        "});" +
+      "});",
+      options: [
+        {replacementsOnly: true}
+      ]
+    },
+    {
+      code: "describe('123', function () {" +
+        "test('123', function () {" +
+          "assert(+a);" +
+        "});" +
+      "});",
+      options: [
+        {replacementsOnly: true}
+      ]
+    }
   ].concat(validTests),
   invalid: [
     {

--- a/tests/lib/rules/no-expressions-in-assertions.js
+++ b/tests/lib/rules/no-expressions-in-assertions.js
@@ -329,6 +329,45 @@ invalidTests = j
   .getCombos();
 
 ruleTester.run("no-expressions-in-assertions", rule, {
-  valid: validTests,
-  invalid: invalidTests
+  valid: [
+    "describe('123', function () {" +
+      "test('123', function () {" +
+        "assert(`ok`);" +
+      "});" +
+    "});",
+    "describe('123', function () {" +
+      "test('123', function () {" +
+        "expect(`ok`);" +
+      "});" +
+    "});",
+    "describe('123', function () {" +
+      "test('123', function () {" +
+        "assert.equal(`ok`);" +
+      "});" +
+    "});"
+  ].concat(validTests),
+  invalid: [
+    {
+      code:
+        "describe('123', function () {" +
+          "test('123', function () {" +
+            "assert(a === undefined);" +
+          "});" +
+        "});",
+      errors: [
+        {message: "`.isUndefined` should be used.", type: "CallExpression"}
+      ]
+    },
+    {
+      code:
+        "describe('123', function () {" +
+          "test('123', function () {" +
+            "assert(a !== undefined);" +
+          "});" +
+        "});",
+      errors: [
+        {message: "`.isDefined` should be used.", type: "CallExpression"}
+      ]
+    }
+  ].concat(invalidTests)
 });

--- a/tests/lib/rules/no-same-titles.js
+++ b/tests/lib/rules/no-same-titles.js
@@ -112,6 +112,12 @@ var validTestTemplates = [
         "});" +
       "});",
     options: [{scope: "file", skipSkipped: true}]
+  },
+  {
+    code:
+      "{{SUITE}}('4321', {{ES}} " +
+        "{{TEST}}(foo, {{ES}}}); " +
+      "});"
   }
 ];
 

--- a/tests/lib/utils/node.js
+++ b/tests/lib/utils/node.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var assert = require("assert");
+var espree = require("espree");
+var node = require("../../../lib/utils/node.js");
+
+describe("obj", function () {
+  it("`isSuiteBody` (`isBlockBody`) called with node with no parent", function () {
+    var result = node.isSuiteBody(espree.parse(""));
+    assert(!result);
+  });
+
+  it("`getParentExpression` (`_getParentByTypes`) called with node with no parent", function () {
+    var result = node.getParentExpression(espree.parse(""));
+    assert(!result);
+  });
+});

--- a/tests/lib/utils/obj.js
+++ b/tests/lib/utils/obj.js
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview Unit testing of `obj.js`'s currently unused methods
+ */
+
+"use strict";
+
+var assert = require("assert");
+var obj = require("../../../lib/utils/obj.js");
+
+describe("obj", function () {
+  it("Returns false for absent child path", function () {
+    var result = obj.has({a: {b: {c: 1}}}, "a.b.d");
+    assert(!result);
+  });
+  it("Returns true for present child path", function () {
+    var result = obj.has({a: {b: {c: 1}}}, "a.b.c");
+    assert(result);
+  });
+});


### PR DESCRIPTION
Builds on #12 and #14.

- Enhancement (`no-expressions-in-assertions`): Add `replacementsOnly` option
    which only reports when replacements are possible (or if there are empty
    arguments) and not for regular cases where there are no suggested
    replacements.